### PR TITLE
Feature/south african licence codes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -960,6 +960,9 @@ echo $faker->companyNumber; // 1999/789634/01
 
 // Generates a random national identification number
 echo $faker->idNumber; // 6606192211041
+
+// Generates a random valid licence code
+echo $faker->licenceCode; // EB
 ```
 
 ### `Faker\Provider\en_ZA\PhoneNumber`

--- a/src/Faker/Provider/en_ZA/Person.php
+++ b/src/Faker/Provider/en_ZA/Person.php
@@ -130,10 +130,9 @@ class Person extends \Faker\Provider\Person
     /**
      * @link https://en.wikipedia.org/wiki/National_identification_number#South_Africa
      *
-     * @param int    $minAge
-     * @param int    $maxAge
-     * @param bool   $citizen
-     * @param string $gender
+     * @param \DateTime $birthdate
+     * @param bool      $citizen
+     * @param string    $gender
      *
      * @return string
      */

--- a/src/Faker/Provider/en_ZA/Person.php
+++ b/src/Faker/Provider/en_ZA/Person.php
@@ -127,6 +127,8 @@ class Person extends \Faker\Provider\Person
         'Pule', 'Hlophe', 'Miya', 'Moagi',
     );
 
+    protected static $licenceCodes = array('A', 'A1', 'B', 'C', 'C1', 'C2', 'EB', 'EC', 'EC1', 'I', 'L', 'L1');
+
     /**
      * @link https://en.wikipedia.org/wiki/National_identification_number#South_Africa
      *
@@ -159,5 +161,15 @@ class Person extends \Faker\Provider\Person
         $partialIdNumber = $birthDateString . $genderDigit . $sequenceDigits . $citizenDigit . $raceDigit;
 
         return $partialIdNumber . Luhn::computeCheckDigit($partialIdNumber);
+    }
+
+    /**
+     * @see https://en.wikipedia.org/wiki/Driving_licence_in_South_Africa
+     *
+     * @return string
+     */
+    public function licenceCode()
+    {
+        return static::randomElement(static::$licenceCodes);
     }
 }

--- a/test/Faker/Provider/en_ZA/PersonTest.php
+++ b/test/Faker/Provider/en_ZA/PersonTest.php
@@ -44,4 +44,11 @@ class PersonTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains($genderDigit, array('0', '1', '2', '3', '4'));
     }
+
+    public function testLicenceCode()
+    {
+        $validLicenceCodes = array('A', 'A1', 'B', 'C', 'C1', 'C2', 'EB', 'EC', 'EC1', 'I', 'L', 'L1');
+
+        $this->assertContains($this->faker->licenceCode, $validLicenceCodes);
+    }
 }


### PR DESCRIPTION
* Added licenceCode method to the en_ZA person provider, that generates a valid South African licence code.
* Fixed incorrect docblock on the idNumber method in the en_ZA person provider